### PR TITLE
Update site content to reflect port 8081 and generator v2.1.0

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Generate and push site image
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/rdfpub/generator:2.0.0
+          image: ghcr.io/rdfpub/generator:2.1.0
           options: -v ${{ github.workspace }}/site-files:/rdfpub/input:ro
           run: >
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The easiest way to run this site is to run a pre-built Docker image of the
 site like so (for which you will need [Docker](https://www.docker.com)):
 
 ```bash
-docker run -p 80:80 ghcr.io/rdfpub/tutorial-site
+docker run -p 80:8081 ghcr.io/rdfpub/tutorial-site
 ```
 
 If the image runs successfully, then you should be able to visit the tutorial
@@ -40,7 +40,7 @@ docker run                                     \
   -t rdfpub/tutorial-site
 
 # Run the tutorial site
-docker run -p 80:80 rdfpub/tutorial-site
+docker run -p 80:8081 rdfpub/tutorial-site
 ```
 
 ## Thanks!

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone https://github.com/rdfpub/tutorial-site
 docker run                                     \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v `pwd`/tutorial-site:/rdfpub/input:ro      \
-  ghcr.io/rdfpub/generator                     \
+  ghcr.io/rdfpub/generator:2.1.0               \
   -t rdfpub/tutorial-site
 
 # Run the tutorial site

--- a/lessons/build-run-deploy/data.ttl
+++ b/lessons/build-run-deploy/data.ttl
@@ -24,7 +24,7 @@ so:
 docker run \\
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /path/to/your/site/directory:/rdfpub/input:ro \\
-  ghcr.io/rdfpub/generator \\
+  ghcr.io/rdfpub/generator:2.1.0 \\
   -t rdfpub/example
 ```
 
@@ -39,8 +39,8 @@ To explain each line of the above:
   `/rdfpub/input` directory inside the container which is where the site
   generator builds from; and the `ro` flag to mount it as read-only for
   extra safety
-- `ghcr.io/rdfpub/generator` is the rdfpub site generator Docker image which is
-  hosted at the
+- `ghcr.io/rdfpub/generator:2.1.0` is the rdfpub site generator Docker image
+  which is hosted at the
   [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 - `-t rdfpub/example` specifies how the image should be tagged, plus any other
   parameters to `docker buildx build`; you should supply your own image tag
@@ -61,7 +61,7 @@ git clone https://github.com/rdfpub/tutorial-site
 docker run                                     \\
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v `pwd`/tutorial-site:/rdfpub/input:ro      \\
-  ghcr.io/rdfpub/generator                     \\
+  ghcr.io/rdfpub/generator:2.1.0               \\
   -t rdfpub/tutorial-site
 ```
 

--- a/lessons/build-run-deploy/data.ttl
+++ b/lessons/build-run-deploy/data.ttl
@@ -74,13 +74,15 @@ Once your site image is built, you can run it from the command line using
 `docker run`. Continuing the tutorial site example, you can run it like so:
 
 ```sh
-docker run -p 80:80 rdfpub/tutorial-site
+docker run -p 80:8081 rdfpub/tutorial-site
 ```
 
-The `-p 80:80` runs the container with port 80 (HTTP) inside the container
+The `-p 80:8081` runs the container with port 8081 (HTTP) inside the container
 bound to your local machine's port 80 which allows you to access the site
 using a web browser. You should be able to visit <http://localhost/> if
-everything went according to plan.
+everything went according to plan. Note that binding to ports below 1024
+requires root privileges on Linux, so you might need `sudo` to successfully
+bind the server to your local port 80.
 
 ## Deploying your site
 To deploy your site, you'll need to leverage a service that allows you to run


### PR DESCRIPTION
[rdfpub/generator](https://github.com/rdfpub/generator) has been updated to version 2.1.0 which includes a change to use port 8081 instead of port 80. Changes in this PR reflect those changes in the tutorial site content.