### PR TITLE
Rewrite the readme to be more specific to the repo itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # The rdfpub Tutorial Site
 
-This is the tutorial site for rdfpub, a static-ish site generator for
-publishing rich [RDF](https://www.w3.org/TR/rdf11-primer/) data to the World
-Wide Web. The links at the top of the page can be followed to learn about the
-various facets of an rdfpub site, including instructions and examples for how
-to create your own rdfpub site.
-
-## Source
-
-The [rdfpub source code](https://github.com/rdfpub/generator) is maintained
-at GitHub along with other supporting projects within
-[the rdfpub organization](https://github.com/rdfpub), including
-[the source code for this tutorial site](https://github.com/rdfpub/tutorial-site).
+This is the source for the rdfpub tutorial site, a living example of an rdfpub
+site that documents and demonstrates all the facets of an rdfpub site. Browsing
+[the live tutorial site](https://rdf.pub/tutorial) is the easiest way to
+reference the tutorial, but you can also run the tutorial site on your local
+machine.
 
 ## How to run this site
 
@@ -23,7 +16,7 @@ docker run -p 80:8081 ghcr.io/rdfpub/tutorial-site
 ```
 
 If the image runs successfully, then you should be able to visit the tutorial
-site in your browser at <http://localhost/>.
+site in your browser at <http://localhost/tutorial>.
 
 If you're looking to get more hands-on with rdfpub, you can download the
 tutorial site's code and build it yourself like so:
@@ -43,16 +36,3 @@ docker run                                     \
 docker run -p 80:8081 rdfpub/tutorial-site
 ```
 
-## Thanks!
-
-A big thanks to all of the developers of the projects that rdfpub depends
-on, including but not limited to those who helped develop
-[RDF4J](https://rdf4j.org), [Handlebars](https://handlebarsjs.com),
-[OpenResty](https://openresty.org),
-[markdown-it](https://github.com/markdown-it/markdown-it), and
-[SimpleCSS](https://www.simplecss.org). Projects like rdfpub
-couldn't exist without the bedrock of technologies that all of you have
-contributed to.
-
-And a thanks to you, the person reading this, for taking the time to check
-out this nifty little passion project. 🙂


### PR DESCRIPTION
README.md for the tutorial site was previously a near-copy of its landing page which does not make sense without the context of the other site content. As such, the readme is being rewritten to reference the repository and its purpose while its landing page will continue to reflect the content that was previously duplicated in the readme.