### PR TITLE
Update RDF links to reference the W3C semantic web wiki

### DIFF
--- a/tutorial/index.handlebars
+++ b/tutorial/index.handlebars
@@ -3,7 +3,7 @@
 <main>
   <p>This is the tutorial site for rdfpub, a static-ish site generator for
     publishing rich
-    <a href="https://www.w3.org/TR/rdf11-primer/">RDF</a>
+    <a href="https://www.w3.org/2001/sw/wiki/RDF">RDF</a>
     data to the World Wide Web. The links at the top of the page can be
     followed to learn about the various facets of an rdfpub site, including
     instructions and examples for how to create your own rdfpub site.

--- a/tutorial/lessons/resources/data.ttl
+++ b/tutorial/lessons/resources/data.ttl
@@ -24,7 +24,7 @@ resource in a directory `/foo/bar` would be combined with the site's base URI
 form a URL like `https://example.com/foo/bar`.
 
 ### RDF
-[RDF](https://www.w3.org/TR/rdf11-primer/) is a first-class citizen in rdfpub.
+[RDF](https://www.w3.org/2001/sw/wiki/RDF) is a first-class citizen in rdfpub.
 What makes it so special?
 
 - It is the data that describes everything about your resources


### PR DESCRIPTION
The preferred link to information about RDF is <https://www.w3.org/2001/sw/wiki/RDF>. The informational links about RDF have been updated to use this URL.